### PR TITLE
Using safer-macro to determine if auto-complete-mode is active

### DIFF
--- a/php-eldoc.el
+++ b/php-eldoc.el
@@ -2236,8 +2236,7 @@
 ;;;###autoload
 (defun php-eldoc-enable ()
   (interactive)
-  (when (and (fboundp 'auto-complete-mode)
-             auto-complete-mode)
+  (when (bound-and-true-p auto-complete-mode)
     (pushnew 'ac-source-php-eldoc ac-sources))
   (setq-local eldoc-documentation-function 'php-eldoc-function)
   (eldoc-mode 1))


### PR DESCRIPTION
I don't have auto-complete installed and as a result I get an error at every PHP file I visit complaining about the undefined variable `auto-complete-mode`.
I found the macro `bound-and-true-p` [here](https://stackoverflow.com/questions/10088168/how-to-check-whether-a-minor-mode-e-g-flymake-mode-is-on) which seems to resolve the problem.
Thanks,
Adrien